### PR TITLE
ci: add github-actions ecosystem to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,11 @@ updates:
       python-packages:
         patterns:
           - "*"
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds the `github-actions` package ecosystem to Dependabot so workflow action versions are kept up to date, grouped into a single monthly PR (mirroring the existing pip config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)