### PR TITLE
Offer to install, reload and enable the timer after generating

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 Generates systemd `.timer` and `.service` units to more easily add cron-like tasks to your system.
 
-You'll still have to copy them into the right place (either `/etc/systemd/system`
-or `$HOME/.config/systemd/user`) and reload systemd using `systemctl daemon-reload`.
+After editing the units, the tool can install them for you: copy them into
+`/etc/systemd/system` or `$HOME/.config/systemd/user` (creating the directory if
+needed), run `systemctl daemon-reload`, and enable and start the timer.
 
 ## Usage
 
@@ -11,4 +12,5 @@ or `$HOME/.config/systemd/user`) and reload systemd using `systemctl daemon-relo
 generate-systemd-timer unit-name
 # Now two editors will pop up to allow you to customize
 # Afterwards you'll find unit-name.service and unit-name.timer in the current folder.
+# Finally, you'll be asked whether to install, reload and enable the timer.
 ```

--- a/systemd_generator/__init__.py
+++ b/systemd_generator/__init__.py
@@ -1,8 +1,14 @@
 """Generate systemd timer files"""
+import os
+import subprocess
 import sys
 
 import jinja2
 import editor
+
+
+USER_UNIT_DIR = os.path.expanduser("~/.config/systemd/user")
+SYSTEM_UNIT_DIR = "/etc/systemd/system"
 
 
 TEMPLATE_TIMER = """\
@@ -80,6 +86,75 @@ def _render_service(service_name):
     )
 
 
+def _prompt_yes_no(question, default=False):
+    """Ask a yes/no question on stdin. Returns the default if non-interactive."""
+    if not sys.stdin.isatty():
+        return default
+    options = "[Y/n]" if default else "[y/N]"
+    try:
+        answer = input(f"{question} {options} ").strip().lower()
+    except EOFError:
+        return default
+    if not answer:
+        return default
+    return answer in ("y", "yes")
+
+
+def _run(cmd):
+    """Echo and run a command, returning its exit code."""
+    print(f"+ {' '.join(cmd)}")
+    return subprocess.call(cmd)
+
+
+def _manual_instructions(service_name, target):
+    print(
+        "\nTo install manually:\n"
+        f"  cp {service_name}.service {service_name}.timer {target}/\n"
+        f"  systemctl daemon-reload\n"
+        f"  systemctl enable --now {service_name}.timer"
+    )
+
+
+def _install(service_name):
+    """Offer to copy the units into place, reload systemd and enable the timer."""
+    units = [f"{service_name}.service", f"{service_name}.timer"]
+
+    user_scope = _prompt_yes_no(
+        "Install as a user unit (instead of system-wide)?", default=True
+    )
+    if user_scope:
+        target = USER_UNIT_DIR
+        sudo = []
+        systemctl = ["systemctl", "--user"]
+    else:
+        target = SYSTEM_UNIT_DIR
+        sudo = ["sudo"]
+        systemctl = ["sudo", "systemctl"]
+
+    if not _prompt_yes_no(f"Copy units into {target} now?", default=True):
+        _manual_instructions(service_name, target)
+        return
+
+    if not os.path.isdir(target):
+        if _prompt_yes_no(f"Directory {target} does not exist. Create it?", default=True):
+            if _run(sudo + ["mkdir", "-p", target]) != 0:
+                print("Failed to create directory; aborting install.", file=sys.stderr)
+                return
+        else:
+            _manual_instructions(service_name, target)
+            return
+
+    for unit in units:
+        if _run(sudo + ["cp", unit, os.path.join(target, unit)]) != 0:
+            print(f"Failed to copy {unit}; aborting install.", file=sys.stderr)
+            return
+
+    _run(systemctl + ["daemon-reload"])
+
+    if _prompt_yes_no(f"Enable and start {service_name}.timer now?", default=True):
+        _run(systemctl + ["enable", "--now", f"{service_name}.timer"])
+
+
 def main():
     if len(sys.argv) != 2:
         print(f"Usage: {sys.argv[0]} <service name>", file=sys.stderr)
@@ -93,6 +168,13 @@ def main():
     with open(f'{service_name}.timer', 'w') as f:
         f.write(_render_timer(service_name))
     editor.edit(filename=f'{service_name}.timer')
+
+    if _prompt_yes_no(
+        f"\nGenerated {service_name}.service and {service_name}.timer.\n"
+        "Install them now?",
+        default=False,
+    ):
+        _install(service_name)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #18.

After generating and editing the `.service`/`.timer` pair, the CLI now offers to
do the next steps for you instead of leaving them as a manual chore:

- choose **user** (`~/.config/systemd/user`) or **system** (`/etc/systemd/system`) scope
- **create the target directory** if it doesn't exist
- **copy** both units into place (with `sudo` for system scope)
- run `systemctl daemon-reload`
- optionally `systemctl enable --now <name>.timer`

Every prompt has a sensible default and the whole flow is skipped when stdin is
not a TTY, so scripted/non-interactive use is unchanged. If the user declines,
the equivalent manual commands are printed.

README updated to describe the new step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)