### PR TITLE
chore: bump version to 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "generate-systemd-timer"
-version = "0.1.3"
+version = "2.0.0"
 description = "Generate a systemd unit.timer and unit.service pair"
 license = "MIT"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -31,7 +31,7 @@ wheels = [
 
 [[package]]
 name = "generate-systemd-timer"
-version = "0.1.3"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
Bump version `0.1.3` → `2.0.0`.

Updates `pyproject.toml` and `uv.lock`. After merge, tag `v2.0.0` triggers the publish workflow (build → trusted-publishing to PyPI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)