### PR TITLE
Only offer install when systemctl is present

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Generates systemd `.timer` and `.service` units to more easily add cron-like tas
 
 After editing the units, the tool can install them for you: copy them into
 `/etc/systemd/system` or `$HOME/.config/systemd/user` (creating the directory if
-needed), run `systemctl daemon-reload`, and enable and start the timer.
+needed), run `systemctl daemon-reload`, and enable and start the timer. The
+install step is only offered when `systemctl` is available; otherwise the
+generated units are left in the current directory.
 
 ## Usage
 

--- a/systemd_generator/__init__.py
+++ b/systemd_generator/__init__.py
@@ -1,6 +1,7 @@
 """Generate systemd timer files"""
 
 import os
+import shutil
 import subprocess
 import sys
 
@@ -120,6 +121,11 @@ def _run(cmd):
     return subprocess.call(cmd)
 
 
+def _has_command(name):
+    """Return whether ``name`` is an executable on the PATH."""
+    return shutil.which(name) is not None
+
+
 def _manual_instructions(service_name, target):
     print(
         "\nTo install manually:\n"
@@ -185,11 +191,13 @@ def main():
         f.write(_render_timer(service_name))
     editor.edit(filename=f"{service_name}.timer")
 
-    if _prompt_yes_no(
-        f"\nGenerated {service_name}.service and {service_name}.timer.\n"
-        "Install them now?",
-        default=False,
-    ):
+    print(f"\nGenerated {service_name}.service and {service_name}.timer.")
+
+    if not _has_command("systemctl"):
+        print("systemctl not found; skipping install.")
+        return
+
+    if _prompt_yes_no("Install them now?", default=False):
         _install(service_name)
 
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -389,6 +389,21 @@ class TestInstall:
 
 
 # ---------------------------------------------------------------------------
+# _has_command
+# ---------------------------------------------------------------------------
+
+
+class TestHasCommand:
+    def test_present(self, monkeypatch):
+        monkeypatch.setattr(sg.shutil, "which", lambda name: "/usr/bin/" + name)
+        assert sg._has_command("systemctl") is True
+
+    def test_absent(self, monkeypatch):
+        monkeypatch.setattr(sg.shutil, "which", lambda name: None)
+        assert sg._has_command("systemctl") is False
+
+
+# ---------------------------------------------------------------------------
 # main
 # ---------------------------------------------------------------------------
 
@@ -436,6 +451,7 @@ class TestMain:
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr(sys, "argv", ["prog", "backup"])
         monkeypatch.setattr(sg.editor, "edit", lambda filename: None)
+        monkeypatch.setattr(sg, "_has_command", lambda name: True)
         monkeypatch.setattr(sg, "_prompt_yes_no", lambda *a, **k: True)
         installed = []
         monkeypatch.setattr(sg, "_install", lambda name: installed.append(name))
@@ -448,6 +464,7 @@ class TestMain:
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr(sys, "argv", ["prog", "backup"])
         monkeypatch.setattr(sg.editor, "edit", lambda filename: None)
+        monkeypatch.setattr(sg, "_has_command", lambda name: True)
         monkeypatch.setattr(sg, "_prompt_yes_no", lambda *a, **k: False)
         installed = []
         monkeypatch.setattr(sg, "_install", lambda name: installed.append(name))
@@ -455,3 +472,36 @@ class TestMain:
         sg.main()
 
         assert installed == []
+
+    def test_install_not_offered_without_systemctl(self, monkeypatch, tmp_path, capsys):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(sys, "argv", ["prog", "backup"])
+        monkeypatch.setattr(sg.editor, "edit", lambda filename: None)
+        monkeypatch.setattr(sg, "_has_command", lambda name: False)
+        installed = []
+        monkeypatch.setattr(sg, "_install", lambda name: installed.append(name))
+        # Even if the user would say yes, install must not be offered.
+        prompts = []
+
+        def _record_prompt(question, default=False):
+            prompts.append(question)
+            return True
+
+        monkeypatch.setattr(sg, "_prompt_yes_no", _record_prompt)
+
+        sg.main()
+
+        assert installed == []
+        assert not any("Install" in p for p in prompts)
+        assert "systemctl" in capsys.readouterr().out
+
+    def test_writes_units_without_systemctl(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(sys, "argv", ["prog", "backup"])
+        monkeypatch.setattr(sg.editor, "edit", lambda filename: None)
+        monkeypatch.setattr(sg, "_has_command", lambda name: False)
+
+        sg.main()
+
+        assert (tmp_path / "backup.service").is_file()
+        assert (tmp_path / "backup.timer").is_file()


### PR DESCRIPTION
## What

Gate the install flow behind a `systemctl` presence check.

`main()` now calls a new `_has_command("systemctl")` helper (thin wrapper over `shutil.which`) before offering to install. When `systemctl` is missing:

- generation still runs and writes `*.service` / `*.timer` to the current directory,
- a `systemctl not found; skipping install.` note is printed,
- the install prompt is **not** shown (so the user can't trigger an install that would only fail).

## Why

On a host without systemd (e.g. a dev/macOS machine) the install steps (`cp`, `daemon-reload`, `enable --now`) cannot succeed. No point offering them.

## Tests

- `TestHasCommand` — present / absent.
- `TestMain` — install offered with systemctl, skipped without it, units still written without systemctl.

`uv run pytest` → 54 passed. `ruff check`/`format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)