### PR TITLE
Validate generated units with systemd-analyze verify

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,4 +34,16 @@ jobs:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
       - name: Run pytest
-        run: uv run --frozen pytest
+        run: uv run --frozen pytest -m "not docker"
+
+  docker:
+    name: pytest (docker integration)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+      - name: Run docker integration tests
+        run: uv run --frozen pytest -m docker

--- a/README.md
+++ b/README.md
@@ -8,9 +8,8 @@ needed), run `systemctl daemon-reload`, and enable and start the timer. The
 install step is only offered when `systemctl` is available; otherwise the
 generated units are left in the current directory.
 
-After editing, the tool offers to check the units with `systemd-analyze
-verify` (when that command is available), so syntax errors are caught before
-installation.
+After editing, the tool checks the units with `systemd-analyze verify` (when
+that command is available), so syntax errors are caught before installation.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ needed), run `systemctl daemon-reload`, and enable and start the timer. The
 install step is only offered when `systemctl` is available; otherwise the
 generated units are left in the current directory.
 
+After editing, the tool offers to check the units with `systemd-analyze
+verify` (when that command is available), so syntax errors are caught before
+installation.
+
 ## Usage
 
 ```sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ dev = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-ra"
+markers = [
+    "docker: integration tests that build and run a Docker container (deselect with '-m \"not docker\"')",
+]
 
 [tool.ruff]
 target-version = "py38"

--- a/systemd_generator/__init__.py
+++ b/systemd_generator/__init__.py
@@ -135,6 +135,21 @@ def _manual_instructions(service_name, target):
     )
 
 
+def _validate(service_name):
+    """Run ``systemd-analyze verify`` on the generated units."""
+    if not _has_command("systemd-analyze"):
+        print("systemd-analyze not found; skipping validation.")
+        return
+    units = [f"{service_name}.service", f"{service_name}.timer"]
+    if _run(["systemd-analyze", "verify", *units]) == 0:
+        print("Units passed systemd-analyze verify.")
+    else:
+        print(
+            "systemd-analyze verify reported problems (see above).",
+            file=sys.stderr,
+        )
+
+
 def _install(service_name):
     """Offer to copy the units into place, reload systemd and enable the timer."""
     units = [f"{service_name}.service", f"{service_name}.timer"]
@@ -192,6 +207,11 @@ def main():
     editor.edit(filename=f"{service_name}.timer")
 
     print(f"\nGenerated {service_name}.service and {service_name}.timer.")
+
+    if _has_command("systemd-analyze") and _prompt_yes_no(
+        "Validate the units with systemd-analyze verify?", default=True
+    ):
+        _validate(service_name)
 
     if not _has_command("systemctl"):
         print("systemctl not found; skipping install.")

--- a/systemd_generator/__init__.py
+++ b/systemd_generator/__init__.py
@@ -135,19 +135,99 @@ def _manual_instructions(service_name, target):
     )
 
 
+VERIFY_COMMENT_BEGIN = "# === systemd-analyze verify ==="
+VERIFY_COMMENT_END = "# === end systemd-analyze verify ==="
+
+
+def _verify(units):
+    """Run ``systemd-analyze verify`` capturing its output.
+
+    Returns ``(returncode, output)`` where ``output`` is the combined
+    stdout/stderr (systemd-analyze reports problems on stderr).
+    """
+    cmd = ["systemd-analyze", "verify", *units]
+    print(f"+ {' '.join(cmd)}")
+    proc = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    return proc.returncode, proc.stdout
+
+
+def _strip_verify_comments(text):
+    """Remove a previously-inserted verify comment block from unit text."""
+    out = []
+    skipping = False
+    for line in text.splitlines(keepends=True):
+        stripped = line.strip()
+        if stripped == VERIFY_COMMENT_BEGIN:
+            skipping = True
+            continue
+        if stripped == VERIFY_COMMENT_END:
+            skipping = False
+            continue
+        if not skipping:
+            out.append(line)
+    return "".join(out)
+
+
+def _clear_verify_comments(path):
+    """Drop any verify comment block from the unit file at ``path``."""
+    with open(path) as f:
+        text = f.read()
+    with open(path, "w") as f:
+        f.write(_strip_verify_comments(text))
+
+
+def _annotate_with_verify(path, output):
+    """Append ``output`` as a verify comment block to the unit at ``path``.
+
+    Any existing block is replaced so the annotations do not accumulate.
+    """
+    with open(path) as f:
+        text = _strip_verify_comments(f.read())
+    if text and not text.endswith("\n"):
+        text += "\n"
+    block_lines = [VERIFY_COMMENT_BEGIN]
+    for line in output.splitlines():
+        block_lines.append(f"# {line}".rstrip())
+    block_lines.append(VERIFY_COMMENT_END)
+    with open(path, "w") as f:
+        f.write(text + "\n".join(block_lines) + "\n")
+
+
 def _validate(service_name):
-    """Run ``systemd-analyze verify`` on the generated units."""
+    """Run ``systemd-analyze verify`` on the generated units.
+
+    The combined verify output is echoed and, on failure, appended to each
+    unit file as a comment block so the problems are visible when the file is
+    reopened in the editor. Returns ``True`` when the units are valid (or when
+    ``systemd-analyze`` is unavailable and validation is skipped), ``False``
+    when verify reports problems.
+    """
     if not _has_command("systemd-analyze"):
         print("systemd-analyze not found; skipping validation.")
-        return
+        return True
     units = [f"{service_name}.service", f"{service_name}.timer"]
-    if _run(["systemd-analyze", "verify", *units]) == 0:
+    # Verify the clean files; never feed a previous annotation back in.
+    for unit in units:
+        _clear_verify_comments(unit)
+    returncode, output = _verify(units)
+    if output.strip():
+        print(output)
+    if returncode == 0:
         print("Units passed systemd-analyze verify.")
-    else:
-        print(
-            "systemd-analyze verify reported problems (see above).",
-            file=sys.stderr,
-        )
+        return True
+    for unit in units:
+        _annotate_with_verify(unit, output)
+    print(
+        "systemd-analyze verify reported problems; "
+        "annotated the units (see the comment block).",
+        file=sys.stderr,
+    )
+    return False
 
 
 def _install(service_name):
@@ -208,10 +288,18 @@ def main():
 
     print(f"\nGenerated {service_name}.service and {service_name}.timer.")
 
-    if _has_command("systemd-analyze") and _prompt_yes_no(
-        "Validate the units with systemd-analyze verify?", default=True
-    ):
-        _validate(service_name)
+    # Validate; on failure the units are annotated with the problems and the
+    # editor is reopened so they can be fixed. Only loop when interactive.
+    while not _validate(service_name):
+        if not (
+            sys.stdin.isatty()
+            and _prompt_yes_no(
+                "Validation failed. Re-edit the units to fix it?", default=True
+            )
+        ):
+            break
+        editor.edit(filename=f"{service_name}.service")
+        editor.edit(filename=f"{service_name}.timer")
 
     if not _has_command("systemctl"):
         print("systemctl not found; skipping install.")

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -1,0 +1,6 @@
+# Minimal image providing a real `systemd-analyze` for integration tests.
+FROM debian:trixie-slim
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends systemd \
+    && rm -rf /var/lib/apt/lists/*
+ENTRYPOINT ["systemd-analyze"]

--- a/tests/test_docker_integration.py
+++ b/tests/test_docker_integration.py
@@ -1,0 +1,100 @@
+"""Integration tests that run the generated units through a real
+``systemd-analyze verify`` inside a Docker container.
+
+These are slow (they build an image with systemd on first run) and require a
+working Docker daemon, so the whole module is skipped when Docker is
+unavailable. Select them explicitly with ``-m docker``.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import systemd_generator as sg
+
+pytestmark = pytest.mark.docker
+
+IMAGE_TAG = "systemd-timer-generator-test"
+DOCKERFILE_DIR = Path(__file__).parent / "docker"
+
+
+def _docker_available():
+    if shutil.which("docker") is None:
+        return False
+    return subprocess.run(["docker", "info"], capture_output=True).returncode == 0
+
+
+if not _docker_available():
+    pytest.skip("docker is not available", allow_module_level=True)
+
+
+@pytest.fixture(scope="session")
+def systemd_image():
+    """Build (and cache) the systemd image once per session."""
+    build = subprocess.run(
+        ["docker", "build", "-t", IMAGE_TAG, str(DOCKERFILE_DIR)],
+        capture_output=True,
+        text=True,
+    )
+    if build.returncode != 0:
+        pytest.fail(f"docker build failed:\n{build.stdout}\n{build.stderr}")
+    return IMAGE_TAG
+
+
+def _verify_in_docker(image, unit_dir, names):
+    """Run ``systemd-analyze verify`` on ``names`` inside the container."""
+    args = [f"/units/{name}" for name in names]
+    proc = subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "-v",
+            f"{unit_dir}:/units:ro",
+            image,
+            "verify",
+            *args,
+        ],
+        capture_output=True,
+        text=True,
+    )
+    return proc.returncode, proc.stdout + proc.stderr
+
+
+def test_generated_units_pass_real_verify(systemd_image, tmp_path):
+    """The boilerplate produced by the generator is valid systemd syntax.
+
+    Mirrors the post-edit state: an ``OnCalendar`` is uncommented so the timer
+    actually has an elapse setting.
+    """
+    service = sg._render_service("backup")
+    timer = sg._render_timer("backup").replace("#OnCalendar=", "OnCalendar=daily")
+
+    (tmp_path / "backup.service").write_text(service)
+    (tmp_path / "backup.timer").write_text(timer)
+
+    rc, output = _verify_in_docker(
+        systemd_image, tmp_path, ["backup.service", "backup.timer"]
+    )
+
+    assert rc == 0, f"verify rejected generated units:\n{output}"
+
+
+def test_invalid_unit_fails_real_verify(systemd_image, tmp_path):
+    """A broken directive is rejected, confirming verify actually checks."""
+    (tmp_path / "backup.service").write_text(
+        "[Service]\nType=oneshot\nExecStart=/bin/true\n"
+    )
+    (tmp_path / "backup.timer").write_text(
+        "[Timer]\nOnCalendar=definitely not a calendar\n"
+        "[Install]\nWantedBy=timers.target\n"
+    )
+
+    rc, output = _verify_in_docker(
+        systemd_image, tmp_path, ["backup.service", "backup.timer"]
+    )
+
+    assert rc != 0
+    assert "calendar" in output.lower()

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -394,42 +394,159 @@ class TestInstall:
 
 
 class TestValidate:
-    def test_runs_verify_on_both_units(self, monkeypatch):
+    @staticmethod
+    def _write_units(tmp_path):
+        (tmp_path / "backup.service").write_text("[Service]\nExecStart=/bin/true\n")
+        (tmp_path / "backup.timer").write_text("[Timer]\nOnCalendar=daily\n")
+
+    def test_runs_verify_on_both_units(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        self._write_units(tmp_path)
         monkeypatch.setattr(sg, "_has_command", lambda name: True)
         calls = []
-        monkeypatch.setattr(sg, "_run", lambda cmd: calls.append(cmd) or 0)
+        monkeypatch.setattr(sg, "_verify", lambda units: calls.append(units) or (0, ""))
 
-        sg._validate("backup")
-
-        assert calls == [
-            ["systemd-analyze", "verify", "backup.service", "backup.timer"]
-        ]
+        assert sg._validate("backup") is True
+        assert calls == [["backup.service", "backup.timer"]]
 
     def test_skips_when_analyzer_absent(self, monkeypatch, capsys):
         monkeypatch.setattr(sg, "_has_command", lambda name: False)
         calls = []
-        monkeypatch.setattr(sg, "_run", lambda cmd: calls.append(cmd) or 0)
+        monkeypatch.setattr(sg, "_verify", lambda units: calls.append(units) or (0, ""))
 
-        sg._validate("backup")
-
+        assert sg._validate("backup") is True
         assert calls == []
         assert "systemd-analyze" in capsys.readouterr().out
 
-    def test_reports_success(self, monkeypatch, capsys):
+    def test_passing_units_are_not_annotated(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        self._write_units(tmp_path)
         monkeypatch.setattr(sg, "_has_command", lambda name: True)
-        monkeypatch.setattr(sg, "_run", lambda cmd: 0)
+        monkeypatch.setattr(sg, "_verify", lambda units: (0, "all good"))
 
-        sg._validate("backup")
+        assert sg._validate("backup") is True
+        assert sg.VERIFY_COMMENT_BEGIN not in (tmp_path / "backup.timer").read_text()
 
-        assert "passed" in capsys.readouterr().out.lower()
-
-    def test_reports_failure(self, monkeypatch, capsys):
+    def test_failure_annotates_units_as_comments(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        self._write_units(tmp_path)
         monkeypatch.setattr(sg, "_has_command", lambda name: True)
-        monkeypatch.setattr(sg, "_run", lambda cmd: 1)
+        monkeypatch.setattr(
+            sg, "_verify", lambda units: (1, "backup.timer:2: Unknown key Frob")
+        )
 
-        sg._validate("backup")
+        assert sg._validate("backup") is False
+        for unit in ("backup.service", "backup.timer"):
+            text = (tmp_path / unit).read_text()
+            assert sg.VERIFY_COMMENT_BEGIN in text
+            assert "# backup.timer:2: Unknown key Frob" in text
 
-        assert capsys.readouterr().err  # problems reported on stderr
+    def test_failure_reverifies_clean_files(self, monkeypatch, tmp_path):
+        """A prior annotation must be stripped before re-verifying."""
+        monkeypatch.chdir(tmp_path)
+        self._write_units(tmp_path)
+        monkeypatch.setattr(sg, "_has_command", lambda name: True)
+        seen = []
+
+        def _fake_verify(units):
+            # Capture the timer contents at verify time.
+            seen.append((tmp_path / "backup.timer").read_text())
+            return 1, "boom"
+
+        monkeypatch.setattr(sg, "_verify", _fake_verify)
+
+        sg._validate("backup")  # first run annotates
+        sg._validate("backup")  # second run must verify clean text
+
+        assert sg.VERIFY_COMMENT_BEGIN not in seen[1]
+
+
+# ---------------------------------------------------------------------------
+# _verify
+# ---------------------------------------------------------------------------
+
+
+class TestVerify:
+    def test_captures_returncode_and_output(self, monkeypatch):
+        seen = {}
+
+        class _Proc:
+            returncode = 3
+            stdout = "some output"
+
+        def _fake_run(cmd, **kwargs):
+            seen["cmd"] = cmd
+            seen["kwargs"] = kwargs
+            return _Proc()
+
+        monkeypatch.setattr(subprocess, "run", _fake_run)
+
+        rc, output = sg._verify(["backup.service", "backup.timer"])
+
+        assert rc == 3
+        assert output == "some output"
+        assert seen["cmd"] == [
+            "systemd-analyze",
+            "verify",
+            "backup.service",
+            "backup.timer",
+        ]
+        # stderr folded into stdout so problems (reported on stderr) are captured
+        assert seen["kwargs"]["stderr"] == subprocess.STDOUT
+
+
+# ---------------------------------------------------------------------------
+# verify comment annotations
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyComments:
+    def test_strip_removes_block(self):
+        text = (
+            "[Timer]\n"
+            "OnCalendar=daily\n"
+            f"{sg.VERIFY_COMMENT_BEGIN}\n"
+            "# boom\n"
+            f"{sg.VERIFY_COMMENT_END}\n"
+        )
+        assert sg._strip_verify_comments(text) == "[Timer]\nOnCalendar=daily\n"
+
+    def test_strip_noop_without_block(self):
+        text = "[Timer]\nOnCalendar=daily\n"
+        assert sg._strip_verify_comments(text) == text
+
+    def test_annotate_appends_comment_block(self, tmp_path):
+        path = tmp_path / "backup.timer"
+        path.write_text("[Timer]\nOnCalendar=daily\n")
+
+        sg._annotate_with_verify(str(path), "line one\nline two")
+
+        text = path.read_text()
+        assert "# line one" in text
+        assert "# line two" in text
+        assert text.startswith("[Timer]\nOnCalendar=daily\n")
+
+    def test_annotate_replaces_existing_block(self, tmp_path):
+        path = tmp_path / "backup.timer"
+        path.write_text("[Timer]\nOnCalendar=daily\n")
+
+        sg._annotate_with_verify(str(path), "old problem")
+        sg._annotate_with_verify(str(path), "new problem")
+
+        text = path.read_text()
+        assert "# new problem" in text
+        assert "# old problem" not in text
+        assert text.count(sg.VERIFY_COMMENT_BEGIN) == 1
+
+    def test_annotate_comment_lines_start_at_column_zero(self, tmp_path):
+        path = tmp_path / "backup.timer"
+        path.write_text("[Timer]\nOnCalendar=daily\n")
+
+        sg._annotate_with_verify(str(path), "  indented problem")
+
+        for line in path.read_text().splitlines():
+            if line.lstrip().startswith("#"):
+                assert line == line.lstrip()
 
 
 # ---------------------------------------------------------------------------
@@ -497,7 +614,7 @@ class TestMain:
         monkeypatch.setattr(sg.editor, "edit", lambda filename: None)
         monkeypatch.setattr(sg, "_has_command", lambda name: True)
         monkeypatch.setattr(sg, "_prompt_yes_no", lambda *a, **k: True)
-        monkeypatch.setattr(sg, "_validate", lambda name: None)
+        monkeypatch.setattr(sg, "_validate", lambda name: True)
         installed = []
         monkeypatch.setattr(sg, "_install", lambda name: installed.append(name))
 
@@ -511,6 +628,7 @@ class TestMain:
         monkeypatch.setattr(sg.editor, "edit", lambda filename: None)
         monkeypatch.setattr(sg, "_has_command", lambda name: True)
         monkeypatch.setattr(sg, "_prompt_yes_no", lambda *a, **k: False)
+        monkeypatch.setattr(sg, "_validate", lambda name: True)
         installed = []
         monkeypatch.setattr(sg, "_install", lambda name: installed.append(name))
 
@@ -540,31 +658,71 @@ class TestMain:
         assert not any("Install" in p for p in prompts)
         assert "systemctl" in capsys.readouterr().out
 
-    def test_validate_invoked_when_confirmed(self, monkeypatch, tmp_path):
+    def test_validate_always_runs(self, monkeypatch, tmp_path):
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr(sys, "argv", ["prog", "backup"])
         monkeypatch.setattr(sg.editor, "edit", lambda filename: None)
-        monkeypatch.setattr(sg, "_has_command", lambda name: name == "systemd-analyze")
-        monkeypatch.setattr(sg, "_prompt_yes_no", lambda *a, **k: True)
+        monkeypatch.setattr(sg, "_has_command", lambda name: False)
+        # No prompt should gate validation; it runs unconditionally.
+        monkeypatch.setattr(sg, "_prompt_yes_no", lambda *a, **k: False)
         validated = []
-        monkeypatch.setattr(sg, "_validate", lambda name: validated.append(name))
+        monkeypatch.setattr(
+            sg, "_validate", lambda name: validated.append(name) or True
+        )
 
         sg.main()
 
         assert validated == ["backup"]
 
-    def test_validate_skipped_without_analyzer(self, monkeypatch, tmp_path):
+    def test_failed_validation_reopens_editor(self, monkeypatch, tmp_path):
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr(sys, "argv", ["prog", "backup"])
-        monkeypatch.setattr(sg.editor, "edit", lambda filename: None)
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
         monkeypatch.setattr(sg, "_has_command", lambda name: False)
         monkeypatch.setattr(sg, "_prompt_yes_no", lambda *a, **k: True)
-        validated = []
-        monkeypatch.setattr(sg, "_validate", lambda name: validated.append(name))
+        edits = []
+        monkeypatch.setattr(sg.editor, "edit", lambda filename: edits.append(filename))
+        # Fail the first validation, pass after the re-edit.
+        results = iter([False, True])
+        monkeypatch.setattr(sg, "_validate", lambda name: next(results))
 
         sg.main()
 
-        assert validated == []
+        # Both units edited once initially, then again after the failure.
+        assert edits.count("backup.service") == 2
+        assert edits.count("backup.timer") == 2
+
+    def test_failed_validation_stops_when_declined(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(sys, "argv", ["prog", "backup"])
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+        monkeypatch.setattr(sg, "_has_command", lambda name: False)
+        monkeypatch.setattr(sg, "_prompt_yes_no", lambda *a, **k: False)
+        edits = []
+        monkeypatch.setattr(sg.editor, "edit", lambda filename: edits.append(filename))
+        monkeypatch.setattr(sg, "_validate", lambda name: False)
+
+        sg.main()
+
+        # Declined re-edit: only the initial edit of each unit.
+        assert edits.count("backup.service") == 1
+        assert edits.count("backup.timer") == 1
+
+    def test_failed_validation_does_not_loop_when_non_interactive(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(sys, "argv", ["prog", "backup"])
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+        monkeypatch.setattr(sg, "_has_command", lambda name: False)
+        edits = []
+        monkeypatch.setattr(sg.editor, "edit", lambda filename: edits.append(filename))
+        # Always fail; without a tty the loop must not spin forever.
+        monkeypatch.setattr(sg, "_validate", lambda name: False)
+
+        sg.main()
+
+        assert edits.count("backup.service") == 1
 
     def test_writes_units_without_systemctl(self, monkeypatch, tmp_path):
         monkeypatch.chdir(tmp_path)

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -389,6 +389,50 @@ class TestInstall:
 
 
 # ---------------------------------------------------------------------------
+# _validate
+# ---------------------------------------------------------------------------
+
+
+class TestValidate:
+    def test_runs_verify_on_both_units(self, monkeypatch):
+        monkeypatch.setattr(sg, "_has_command", lambda name: True)
+        calls = []
+        monkeypatch.setattr(sg, "_run", lambda cmd: calls.append(cmd) or 0)
+
+        sg._validate("backup")
+
+        assert calls == [
+            ["systemd-analyze", "verify", "backup.service", "backup.timer"]
+        ]
+
+    def test_skips_when_analyzer_absent(self, monkeypatch, capsys):
+        monkeypatch.setattr(sg, "_has_command", lambda name: False)
+        calls = []
+        monkeypatch.setattr(sg, "_run", lambda cmd: calls.append(cmd) or 0)
+
+        sg._validate("backup")
+
+        assert calls == []
+        assert "systemd-analyze" in capsys.readouterr().out
+
+    def test_reports_success(self, monkeypatch, capsys):
+        monkeypatch.setattr(sg, "_has_command", lambda name: True)
+        monkeypatch.setattr(sg, "_run", lambda cmd: 0)
+
+        sg._validate("backup")
+
+        assert "passed" in capsys.readouterr().out.lower()
+
+    def test_reports_failure(self, monkeypatch, capsys):
+        monkeypatch.setattr(sg, "_has_command", lambda name: True)
+        monkeypatch.setattr(sg, "_run", lambda cmd: 1)
+
+        sg._validate("backup")
+
+        assert capsys.readouterr().err  # problems reported on stderr
+
+
+# ---------------------------------------------------------------------------
 # _has_command
 # ---------------------------------------------------------------------------
 
@@ -453,6 +497,7 @@ class TestMain:
         monkeypatch.setattr(sg.editor, "edit", lambda filename: None)
         monkeypatch.setattr(sg, "_has_command", lambda name: True)
         monkeypatch.setattr(sg, "_prompt_yes_no", lambda *a, **k: True)
+        monkeypatch.setattr(sg, "_validate", lambda name: None)
         installed = []
         monkeypatch.setattr(sg, "_install", lambda name: installed.append(name))
 
@@ -494,6 +539,32 @@ class TestMain:
         assert installed == []
         assert not any("Install" in p for p in prompts)
         assert "systemctl" in capsys.readouterr().out
+
+    def test_validate_invoked_when_confirmed(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(sys, "argv", ["prog", "backup"])
+        monkeypatch.setattr(sg.editor, "edit", lambda filename: None)
+        monkeypatch.setattr(sg, "_has_command", lambda name: name == "systemd-analyze")
+        monkeypatch.setattr(sg, "_prompt_yes_no", lambda *a, **k: True)
+        validated = []
+        monkeypatch.setattr(sg, "_validate", lambda name: validated.append(name))
+
+        sg.main()
+
+        assert validated == ["backup"]
+
+    def test_validate_skipped_without_analyzer(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(sys, "argv", ["prog", "backup"])
+        monkeypatch.setattr(sg.editor, "edit", lambda filename: None)
+        monkeypatch.setattr(sg, "_has_command", lambda name: False)
+        monkeypatch.setattr(sg, "_prompt_yes_no", lambda *a, **k: True)
+        validated = []
+        monkeypatch.setattr(sg, "_validate", lambda name: validated.append(name))
+
+        sg.main()
+
+        assert validated == []
 
     def test_writes_units_without_systemctl(self, monkeypatch, tmp_path):
         monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
## What

After the `.service`/`.timer` pair is generated and edited, validate it with `systemd-analyze verify`:

- **Runs automatically** (no prompt) once units are written/edited.
- **Output captured** and echoed; systemd-analyze reports problems on stderr, folded into the capture.
- **On failure the units are annotated**: the verify output is appended to each unit file as a `# === systemd-analyze verify ===` comment block, so the problems are visible inline when the file is reopened. The block is stripped before each re-verify so it never accumulates or gets fed back in.
- **Kicks back to the editor**: a failed validation reopens the editor for both units and re-validates, looping until they pass or the user declines. Interactive only (a non-tty session does not loop).
- Self-gates on `systemd-analyze` being present (skips with a note otherwise).

## Why

> can we somehow validate the generated units? ... validate should just run always ... if validation fails kick back to the editor ... output should be added as a comment to the file

`systemd-analyze verify` parses the units and flags syntax errors before install. Surfacing the errors as comments in the file makes them actionable right where they're edited.

## Tests

- `TestVerify` / `TestVerifyComments` — capturing runner, comment strip/annotate/replace, column-0 comments.
- `TestValidate` — verifies clean files, annotates on failure, no annotation on success, re-verifies stripped text.
- `TestMain` — validation always runs, reopens editor on failure, stops when declined, no infinite loop without a tty.
- **`tests/test_docker_integration.py`** — builds a Debian+systemd image and runs the generated units through a **real** `systemd-analyze verify`: generated boilerplate passes, a bad `OnCalendar` is rejected. Skipped without Docker; `docker` pytest marker.

`uv run pytest` → 71 passed (incl. Docker locally). `ruff check`/`format --check` clean.

## Note

> **Stacked on #31** (`feat-systemctl-guard`) — reuses the `_has_command` helper introduced there. Base retargets to `main` once #31 merges. Review/merge #31 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)